### PR TITLE
feat: add requestInterceptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,34 @@ import { setTransferHeaders } from 'koa-auto-transfer-header';
 
 setTransferHeaders(['my-header1', 'my-header2']);
 ```
+
+interceptors
+
+```typescript
+import { requestInterceptor } from 'koa-auto-transfer-header';
+
+requestInterceptor.use((request: RequestInit | http.ClientRequest | http2.ClientHttp2Stream | http.ClientRequest;) => {
+	console.log('Do something with request')
+})
+```
+
+use storage
+
+```typescript
+const Koa = require('koa');
+const Router = require('@koa/router');
+const app = new Koa();
+const router = new Router();
+
+app.use(async (ctx, next) => {
+    storage.enable(async () => {
+        storage.setItem('__KEY__', { name: 123 })
+        await next();
+    })
+});
+
+router.get('/', (ctx, next) => {
+    console.log(storage.get('__KEY__')); // console log { name: 123 }
+    ctx.body = "Hello 200";
+})
+```

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,8 @@
 import { IConfig } from "./interface/IConfig";
+import * as http from 'http';
+import * as http2 from 'http2';
+
+export type IRequestInterceptor = RequestInit | http.ClientRequest | http2.ClientHttp2Stream | http.ClientRequest;
 
 export const config: IConfig = {
     transferHeaders: [
@@ -9,3 +13,5 @@ export const config: IConfig = {
 
     enable: true,
 };
+
+export const requestInterceptorArr: ((request: IRequestInterceptor) => void)[] = [];

--- a/src/http-request.ts
+++ b/src/http-request.ts
@@ -1,6 +1,6 @@
 import * as http from 'http';
 
-import { config } from './config';
+import { config, requestInterceptorArr } from './config';
 import { storage } from './storage';
 
 const httpRequest = http.request;
@@ -16,6 +16,10 @@ Object.defineProperty(http, 'request', {
                     client.setHeader(headerKey, value);
             });
 
+        for(const interceptor of requestInterceptorArr) {
+            if(typeof interceptor === 'function')
+                interceptor(client);
+        }
         return client;
     },
     enumerable: true,

--- a/src/http2-request.ts
+++ b/src/http2-request.ts
@@ -1,7 +1,7 @@
 import * as http2 from 'http2';
 import { Socket } from 'net';
 import { TLSSocket } from 'tls';
-import { config } from './config';
+import { config, requestInterceptorArr } from './config';
 import { storage } from './storage';
 
 const connect = http2.connect;
@@ -28,6 +28,10 @@ Object.defineProperty(http2, 'connect', {
 
                 const req = request.apply(session, [headers, options]);
 
+                for(const interceptor of requestInterceptorArr) {
+                    if(typeof interceptor === 'function')
+                        interceptor(req);
+                }
                 return req;
             },
             enumerable: true,

--- a/src/https-request.ts
+++ b/src/https-request.ts
@@ -1,7 +1,7 @@
 import { IncomingMessage } from 'http';
 import * as https from 'https';
 
-import { config } from './config';
+import { config, requestInterceptorArr } from './config';
 import { storage } from './storage';
 
 const httpsRequest = https.request;
@@ -17,6 +17,10 @@ Object.defineProperty(https, 'request', {
                     client.setHeader(headerKey, value);
             });
 
+        for(const interceptor of requestInterceptorArr) {
+            if(typeof interceptor === 'function')
+                interceptor(client);
+        }
         return client;
     },
     enumerable: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import './http-request';
 import './https-request';
 import './http2-request';
 
-import { config } from './config';
+import { config, requestInterceptorArr, IRequestInterceptor } from './config';
 import assert = require('assert');
 
 export function disableTransferHeaders() {
@@ -24,6 +24,12 @@ export function addTransferHeader(header: string) {
     if(!config.transferHeaders.includes(header))
         config.transferHeaders.push(header);
 }
+
+export const requestInterceptor = {
+    use: (callback: (request: IRequestInterceptor) => void) => {
+        requestInterceptorArr.push(callback);
+    }
+};
 
 export class HeaderTransferHandle {
     static disableTransferHeaders = disableTransferHeaders;

--- a/src/re-fetch.ts
+++ b/src/re-fetch.ts
@@ -19,8 +19,8 @@ Object.defineProperty(global, 'fetch', {
             init.headers = headers;
 
             for(const interceptor of requestInterceptorArr) {
-                if(interceptor)
-                    await interceptor(init);
+                if(typeof interceptor === 'function')
+                    interceptor(init);
             }
         }
 

--- a/src/re-fetch.ts
+++ b/src/re-fetch.ts
@@ -1,4 +1,4 @@
-import { config } from "./config";
+import { config, requestInterceptorArr } from "./config";
 import { storage } from "./storage";
 
 const globalFetch = global.fetch;
@@ -17,6 +17,11 @@ Object.defineProperty(global, 'fetch', {
             }
 
             init.headers = headers;
+
+            for(const interceptor of requestInterceptorArr) {
+                if(interceptor)
+                    await interceptor(init);
+            }
         }
 
         return globalFetch(input, init);

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -18,5 +18,11 @@ export const storage = {
     },
     set(value: IncomingHttpHeaders) {
         asyncLocalStorage.getStore()?.set(STORAGE_KEY, value);
+    },
+    getItem(key: string) {
+        return asyncLocalStorage.getStore()?.get(Symbol.for(key));
+    },
+    setItem(key: string, value: any) {
+        asyncLocalStorage.getStore()?.set(Symbol.for(key), value);
     }
 };


### PR DESCRIPTION
interceptors

```typescript
import { requestInterceptor } from 'koa-auto-transfer-header';

requestInterceptor.use((request: RequestInit | http.ClientRequest | http2.ClientHttp2Stream | http.ClientRequest;) => {
	console.log('Do something with request')
})
```

use storage

```typescript
const Koa = require('koa');
const Router = require('@koa/router');
const app = new Koa();
const router = new Router();

app.use(async (ctx, next) => {
    storage.enable(async () => {
        storage.setItem('__KEY__', { name: 123 })
        await next();
    })
});

router.get('/', (ctx, next) => {
    console.log(storage.get('__KEY__')); // console log { name: 123 }
    ctx.body = "Hello 200";
})
```