### PR TITLE
feat: add RequestHeadersHook

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,13 @@ import { setTransferHeaders } from 'koa-auto-transfer-header';
 
 setTransferHeaders(['my-header1', 'my-header2']);
 ```
+
+add request headers hook
+
+```typescript
+import { RequestHeadersHook } from 'koa-auto-transfer-header';
+
+RequestHeadersHook.register('x-headers-tag', () => {
+    return { 'x-headers-tag': '123' }
+})
+```

--- a/README.md
+++ b/README.md
@@ -60,7 +60,15 @@ add request headers hook
 ```typescript
 import { RequestHeadersHook } from 'koa-auto-transfer-header';
 
-RequestHeadersHook.register('x-headers-tag', () => {
-    return { 'x-headers-tag': '123' }
-})
+const foo = () => {
+	return { 'x-headers-foo': '123' }
+}
+const bar = () => {
+	return { 'x-headers-bar': '123' }
+}
+RequestHeadersHook.register(foo)
+RequestHeadersHook.register(bar)
+
+// cancel the register
+RequestHeadersHook.unregister(foo)
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "koa-auto-transfer-header",
-    "version": "1.2.4",
+    "version": "1.3.0",
     "description": "auto transfer header in each http-request when server receive a request",
     "main": "dist/index.js",
     "scripts": {

--- a/src/http-request.ts
+++ b/src/http-request.ts
@@ -11,12 +11,13 @@ Object.defineProperty(http, 'request', {
         const client = httpRequest(options, callback);
 
         if(config.enable) {
+            RequestHeadersHook.handle().map(([key, value]) => { client.setHeader(key, value);});
             config.transferHeaders.map(headerKey => {
                 const value = storage.get(headerKey);
+                client.getHeaders();
                 if(value)
                     client.setHeader(headerKey, value);
             });
-            RequestHeadersHook.handle().map(([key, value]) => { client.setHeader(key, value);});
         }
 
         return client;

--- a/src/http-request.ts
+++ b/src/http-request.ts
@@ -2,6 +2,7 @@ import * as http from 'http';
 
 import { config } from './config';
 import { storage } from './storage';
+import { RequestHeadersHook } from './request-headers-hook';
 
 const httpRequest = http.request;
 
@@ -9,12 +10,14 @@ Object.defineProperty(http, 'request', {
     value: (options: string | http.RequestOptions | URL, callback: ((res: http.IncomingMessage) => void) | undefined)=> {
         const client = httpRequest(options, callback);
 
-        if(config.enable)
+        if(config.enable) {
             config.transferHeaders.map(headerKey => {
                 const value = storage.get(headerKey);
                 if(value)
                     client.setHeader(headerKey, value);
             });
+            RequestHeadersHook.handle().map(([key, value]) => { client.setHeader(key, value);});
+        }
 
         return client;
     },

--- a/src/http-request.ts
+++ b/src/http-request.ts
@@ -14,7 +14,6 @@ Object.defineProperty(http, 'request', {
             RequestHeadersHook.handle().map(([key, value]) => { client.setHeader(key, value);});
             config.transferHeaders.map(headerKey => {
                 const value = storage.get(headerKey);
-                client.getHeaders();
                 if(value)
                     client.setHeader(headerKey, value);
             });

--- a/src/http2-request.ts
+++ b/src/http2-request.ts
@@ -3,6 +3,7 @@ import { Socket } from 'net';
 import { TLSSocket } from 'tls';
 import { config } from './config';
 import { storage } from './storage';
+import { RequestHeadersHook } from './request-headers-hook';
 
 const connect = http2.connect;
 
@@ -24,6 +25,10 @@ Object.defineProperty(http2, 'connect', {
                         headers[`grpc-metadata-${headerKey}`] = value;
                     }
 
+                });
+
+                RequestHeadersHook.handle().map(([key, value]) => {
+                    headers[key] = value;
                 });
 
                 const req = request.apply(session, [headers, options]);

--- a/src/http2-request.ts
+++ b/src/http2-request.ts
@@ -18,6 +18,10 @@ Object.defineProperty(http2, 'connect', {
 
         Object.defineProperty(session, 'request', {
             value: function(headers: http2.OutgoingHttpHeaders, options?: http2.ClientSessionRequestOptions) {
+                RequestHeadersHook.handle().map(([key, value]) => {
+                    headers[key] = value;
+                });
+
                 config.transferHeaders.map(headerKey => {
                     const value = storage.get(headerKey);
                     if(value) {
@@ -25,10 +29,6 @@ Object.defineProperty(http2, 'connect', {
                         headers[`grpc-metadata-${headerKey}`] = value;
                     }
 
-                });
-
-                RequestHeadersHook.handle().map(([key, value]) => {
-                    headers[key] = value;
                 });
 
                 const req = request.apply(session, [headers, options]);

--- a/src/https-request.ts
+++ b/src/https-request.ts
@@ -12,12 +12,13 @@ Object.defineProperty(https, 'request', {
         const client = httpsRequest(options, callback);
 
         if(config.enable) {
+            RequestHeadersHook.handle().map(([key, value]) => { client.setHeader(key, value);});
+
             config.transferHeaders.map(headerKey => {
                 const value = storage.get(headerKey);
                 if(value)
                     client.setHeader(headerKey, value);
             });
-            RequestHeadersHook.handle().map(([key, value]) => { client.setHeader(key, value);});
         }
 
         return client;

--- a/src/https-request.ts
+++ b/src/https-request.ts
@@ -3,6 +3,7 @@ import * as https from 'https';
 
 import { config } from './config';
 import { storage } from './storage';
+import { RequestHeadersHook } from './request-headers-hook';
 
 const httpsRequest = https.request;
 
@@ -10,12 +11,14 @@ Object.defineProperty(https, 'request', {
     value: (options: string | https.RequestOptions | URL, callback: ((res: IncomingMessage) => void) | undefined)=> {
         const client = httpsRequest(options, callback);
 
-        if(config.enable)
+        if(config.enable) {
             config.transferHeaders.map(headerKey => {
                 const value = storage.get(headerKey);
                 if(value)
                     client.setHeader(headerKey, value);
             });
+            RequestHeadersHook.handle().map(([key, value]) => { client.setHeader(key, value);});
+        }
 
         return client;
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,3 +38,5 @@ export class HeaderTransferHandle {
 }
 
 export * from './storage';
+
+export * from './request-headers-hook';

--- a/src/re-fetch.ts
+++ b/src/re-fetch.ts
@@ -1,5 +1,6 @@
 import { config } from "./config";
 import { storage } from "./storage";
+import { RequestHeadersHook } from './request-headers-hook';
 
 const globalFetch = global.fetch;
 
@@ -15,6 +16,8 @@ Object.defineProperty(global, 'fetch', {
                 if(value)
                     headers[headerKey] = value;
             }
+
+            RequestHeadersHook.handle().map(([key, value]) => { headers[key] = value; });
 
             init.headers = headers;
         }

--- a/src/re-fetch.ts
+++ b/src/re-fetch.ts
@@ -11,13 +11,13 @@ Object.defineProperty(global, 'fetch', {
                 init = { headers: {} };
             const headers = init.headers || {};
 
+            RequestHeadersHook.handle().map(([key, value]) => { headers[key] = value; });
+
             for(const headerKey of config.transferHeaders) {
                 const value = storage.get(headerKey);
                 if(value)
                     headers[headerKey] = value;
             }
-
-            RequestHeadersHook.handle().map(([key, value]) => { headers[key] = value; });
 
             init.headers = headers;
         }

--- a/src/request-headers-hook.ts
+++ b/src/request-headers-hook.ts
@@ -1,19 +1,20 @@
+type ICallback = () => {[key: string]: string};
 export class RequestHeadersHook {
-    private static hooks: any[] = [];
+    private static hooks: Set<ICallback> = new Set();
 
-    static register (name: string, callback: () => {[key: string]: string}) {
-        this.hooks.push({name, callback});
+    static register (callback: ICallback) {
+        this.hooks.add(callback);
     }
 
-    static unregister (name: string) {
-        this.hooks = this.hooks.filter(hook => hook.name !== name);
+    static unregister (callback: ICallback) {
+        this.hooks.delete(callback);
     }
 
     static handle() {
-        const headers = this.hooks.reduce((acc, hook) => {
-            const header = hook.callback();
-            return Object.assign(acc, header);
+        const headers: {[key: string]: string} = Array.from(this.hooks).reduce((acc, hook) => {
+            const header = hook();
+            return { ...acc, ...header };
         }, {});
-        return Object.keys(headers).map(key => [key, headers[key]]);
+        return Object.entries(headers);
     }
 }

--- a/src/request-headers-hook.ts
+++ b/src/request-headers-hook.ts
@@ -1,0 +1,19 @@
+export class RequestHeadersHook {
+    private static hooks: any[] = [];
+
+    static register (name: string, callback: () => {[key: string]: string}) {
+        this.hooks.push({name, callback});
+    }
+
+    static unregister (name: string) {
+        this.hooks = this.hooks.filter(hook => hook.name !== name);
+    }
+
+    static handle() {
+        const headers = this.hooks.reduce((acc, hook) => {
+            const header = hook.callback();
+            return Object.assign(acc, header);
+        }, {});
+        return Object.keys(headers).map(key => [key, headers[key]]);
+    }
+}


### PR DESCRIPTION
add request headers hook

```typescript
import { RequestHeadersHook } from 'koa-auto-transfer-header';

const foo = () => {
	return { 'x-headers-foo': '123' }
}
const bar = () => {
	return { 'x-headers-bar': '123' }
}
RequestHeadersHook.register(foo)
RequestHeadersHook.register(bar)

// cancel the register
RequestHeadersHook.unregister(foo)
```